### PR TITLE
Color: Remove inheritance of AwtColor

### DIFF
--- a/app/src/main/kotlin/be/zvz/kookie/color/Color.kt
+++ b/app/src/main/kotlin/be/zvz/kookie/color/Color.kt
@@ -19,8 +19,8 @@ package be.zvz.kookie.color
 
 import java.awt.Color as AwtColor
 
-class Color(r: Int, g: Int, b: Int, a: Int = 0xff) {
-    private val awtColor = AwtColor(r, g, b, a)
+class Color(val awtColor: AwtColor) {
+    @JvmOverloads constructor(r: Int, g: Int, b: Int, a: Int = 0xff) : this(AwtColor(r, g, b, a))
 
     val red: Int
         get() = awtColor.red

--- a/app/src/main/kotlin/be/zvz/kookie/color/Color.kt
+++ b/app/src/main/kotlin/be/zvz/kookie/color/Color.kt
@@ -20,8 +20,6 @@ package be.zvz.kookie.color
 import java.awt.Color as AwtColor
 
 class Color(val awtColor: AwtColor) {
-    @JvmOverloads constructor(r: Int, g: Int, b: Int, a: Int = 0xff) : this(AwtColor(r, g, b, a))
-
     val red: Int
         get() = awtColor.red
 
@@ -33,6 +31,9 @@ class Color(val awtColor: AwtColor) {
 
     val alpha: Int
         get() = awtColor.alpha
+
+    @JvmOverloads
+    constructor(r: Int, g: Int, b: Int, a: Int = 0xff) : this(AwtColor(r, g, b, a))
 
     fun toARGB(): Int {
         return (this.alpha shl 24) or (this.red shl 16) or (this.green shl 8) or this.blue

--- a/app/src/main/kotlin/be/zvz/kookie/color/Color.kt
+++ b/app/src/main/kotlin/be/zvz/kookie/color/Color.kt
@@ -19,8 +19,20 @@ package be.zvz.kookie.color
 
 import java.awt.Color as AwtColor
 
-class Color @JvmOverloads constructor(r: Int, g: Int, b: Int, a: Int = 0xff) : AwtColor(r, g, b, a) {
-    constructor(awtColor: AwtColor) : this(awtColor.red, awtColor.green, awtColor.blue, awtColor.alpha)
+class Color(r: Int, g: Int, b: Int, a: Int = 0xff) {
+    private val awtColor = AwtColor(r, g, b, a)
+
+    val red: Int
+        get() = awtColor.red
+
+    val green: Int
+        get() = awtColor.green
+
+    val blue: Int
+        get() = awtColor.blue
+
+    val alpha: Int
+        get() = awtColor.alpha
 
     fun toARGB(): Int {
         return (this.alpha shl 24) or (this.red shl 16) or (this.green shl 8) or this.blue
@@ -33,16 +45,13 @@ class Color @JvmOverloads constructor(r: Int, g: Int, b: Int, a: Int = 0xff) : A
     companion object {
         @JvmStatic
         fun mix(vararg colors: Color): Color {
-            var (a, r, g, b) = listOf(0, 0, 0, 0)
-            colors.forEach {
-                a += it.alpha
-                r += it.red
-                g += it.green
-                b += it.blue
-            }
-
             val count = colors.size
-            return Color(r / count, g / count, b / count, a / count)
+            return Color(
+                colors.sumOf { it.red } / count,
+                colors.sumOf { it.green } / count,
+                colors.sumOf { it.blue } / count,
+                colors.sumOf { it.alpha } / count
+            )
         }
 
         @JvmStatic fun fromRGB(code: Int) = Color(code shr 16 and 0xff, code shr 8 and 0xff, code and 0xff)


### PR DESCRIPTION
The Color class should not extend AwtColor since inheritance makes third
party users be exposed to methods such as createContext() from Color class
which is unnecessary and confusing. Rather it is better to move AwtColor
to the internal state and use it as a helper for further API expansions.